### PR TITLE
Implement indexed access to config line fields.

### DIFF
--- a/ciscoconfparse/ccp_abc.py
+++ b/ciscoconfparse/ccp_abc.py
@@ -90,6 +90,19 @@ class BaseCfgLine(object):
     def __hash__(self):
         return hash(self.hash_arg)
 
+    def __getitem__(self, key):
+        split = self.text.split()
+        if isinstance(key, slice):
+            return ' '.join([split[x] for x in xrange(*key.indices(len(split)))])
+        elif isinstance(key, int):
+            if key < 0:
+                key += len(split)
+            if key >= len(split):
+                raise IndexError('Index out of range')
+            return split[key]
+        else:
+            raise TypeError('Line indicies must be integers')
+
     def hash_arg(self):
         # Just a unique string or each object instance
         return str(self.linenum)+self.text

--- a/sphinx-doc/tutorial_parent_child.rst
+++ b/sphinx-doc/tutorial_parent_child.rst
@@ -85,6 +85,8 @@ instance, if you found an :class:`~models_cisco.IOSCfgLine` object with
 children, you can search the children directly from the parent by using 
 :func:`~models_cisco.IOSCfgLine.re_search_children()`.
 
+
+
 Example: Retrieving text from an :class:`~models_cisco.IOSCfgLine` object
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -93,9 +95,10 @@ This example:
 - Parses through a configuration
 - Finds an :class:`~models_cisco.IOSCfgLine` object with :func:`~ciscoconfparse.CiscoConfParse.find_objects()`
 - Retrieves the configuration text from that object (highlighted in yellow)
+- Retrieves the name of interface from the line
 
 .. code-block:: python
-   :emphasize-lines: 9
+   :emphasize-lines: 10
 
    >>> from ciscoconfparse import CiscoConfParse
    >>> parse = CiscoConfParse([
@@ -106,17 +109,19 @@ This example:
    >>> for obj in parse.find_objects(r"interface"):
    ...     print "Object:", obj
    ...     print "Config text:", obj.text
+   ...     print "Interface name:", obj[1]
    ...
    Object: <IOSCfgLine # 1 'interface Serial1/0'>
    Config text: interface Serial1/0
+   Interface name: Serial1/0
    >>>
    >>> quit()
    [mpenning@tsunami ~]$
 
 In the example, ``obj.text`` refers to the :class:`~models_cisco.IOSCfgLine` 
 ``text`` attribute, which retrieves the text of the original IOS configuration 
-statement.
-
+statement.  Also note that we could extract fields from the text by indexing
+the :class:`~models_cisco.IOSCfgLine` instance.
 
 
 Baseline configuration for these examples


### PR DESCRIPTION
If x is a BaseCfgLine representing 'ip access-group block-stuff in',
x[0] will return 'ip', x[2] will return 'block-stuff' and x[2:4] will
return 'block-stuff in'.