### PR TITLE
CiscoConfParse add classmethod from_string

### DIFF
--- a/ciscoconfparse/ccp_abc.py
+++ b/ciscoconfparse/ccp_abc.py
@@ -126,6 +126,15 @@ class BaseCfgLine(object):
             return self.children[-1].linenum
 
     @property
+    def recursive_text(self):
+        lines=list()
+        lines.append(self.text)
+        if self.has_children:
+            for child in self.children:
+                lines.append(child.recursive_text)
+        return "\r\n".join(lines)
+
+    @property
     def verbose(self):
         if self.has_children:
             return "<%s # %s '%s' (child_indent: %s / len(children): %s / family_endpoint: %s)>" % (self.classname, self.linenum, self.text, self.child_indent, len(self.children), self.family_endpoint) 

--- a/ciscoconfparse/ciscoconfparse.py
+++ b/ciscoconfparse/ciscoconfparse.py
@@ -227,6 +227,14 @@ class CiscoConfParse(object):
                 " an invalid argument\n")
         self.ConfigObjs.CiscoConfParse = self
 
+    @classmethod
+    def from_string(cls,input_string):
+        try:
+            config_lines=input_string.splitlines() #convert string blob to list of lines
+            return cls(config_lines)
+        except Exception as e:
+            raise e
+
     def __repr__(self):
         return "<CiscoConfParse: %s lines / syntax: %s / comment delimiter: '%s' / factory: %s>" % (len(self.ConfigObjs), self.syntax, self.comment_delimiter, self.factory)
 


### PR DESCRIPTION
.from_string() allows easy parsing of configs from chunks of text, i.e. an entire config stored in a database

recursive_text returns text from parent and all children:

![image](https://cloud.githubusercontent.com/assets/13751848/9207692/b71ae808-4034-11e5-8d75-8a7cbe0560bb.png)
