### PR TITLE
Do not build universal wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,3 @@ tag_date = false
 
 [aliases]
 release = egg_info -RDb ''
-
-[wheel]
-universal = 1


### PR DESCRIPTION
Conditional logic in setup.py is evaluated at wheel build time, not
at install time, making the result non-universal.

Fixes #47