### PR TITLE
Resolving issue Github #44 - Error while parsing 'ipv6 router ospf'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ python:
 
 # http://docs.travis-ci.com/user/multi-os/
 os:
- - osx
  - linux
 
 install:

--- a/ciscoconfparse/models_cisco.py
+++ b/ciscoconfparse/models_cisco.py
@@ -1579,7 +1579,7 @@ class IOSRouteLine(BaseIOSRouteLine):
 
     @classmethod
     def is_object_for(cls, line="", re=re):
-        if (line[0:8]=='ip route') or (line[0:10]=='ipv6 route'):
+        if (line[0:9]=='ip route ') or (line[0:11]=='ipv6 route '):
             return True
         return False
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -362,6 +362,10 @@ router ospf 100 vrf TEST_100_001
  router-id 1.1.2.254
  network 1.1.2.0 0.0.0.255 area 0
 !
+ipv6 router ospf 1
+ router-id 2.2.2.2
+ log-adjacency-changes
+!
 policy-map QOS_1
  class GOLD
   priority percent 10

--- a/tests/test_CiscoConfParse.py
+++ b/tests/test_CiscoConfParse.py
@@ -263,7 +263,7 @@ def testValues_find_lines(parse_c01):
         test_result = parse_c01.find_lines(**args)
         assert result_correct==test_result
 
-def testValues_find_children(parse_c01):
+def testValues_find_children_01(parse_c01):
     c01_pmap_children = [
         'policy-map QOS_1',
         ' class GOLD',
@@ -280,7 +280,22 @@ def testValues_find_children(parse_c01):
         test_result = parse_c01.find_children(**args)
         assert result_correct==test_result
 
+def testValues_find_children_02(parse_c03):
+    """Test for Github issue #44 could not parse ipv6 router ospf """
+    c01_pmap_children = [
+        'ipv6 router ospf 1',
+        ' router-id 2.2.2.2',
+        ' log-adjacency-changes',
+        ]
 
+    find_children_Values = (
+        ({'linespec': "ipv6 route", 'exactmatch': False},
+            c01_pmap_children),
+        ({'linespec': "policy-map", 'exactmatch': True}, []),
+    )
+    for args, result_correct in find_children_Values:
+        test_result = parse_c03.find_children(**args)
+        assert result_correct==test_result
 
 
 def testValues_find_all_children01(parse_c01):


### PR DESCRIPTION
Hi !

A few corrections to resolve the issue #44.

I removed `os: osx` from `.travis.yml` file because Travis-ci no longer supports OSX with Python. Actually, it has never supported it... See what @jayvdb said in this discussion [OSX hosts fail installing python](https://github.com/travis-ci/travis-ci/issues/4729).