### PR TITLE
Add 'description' property to 'ASAObjGroupNetwork'

### DIFF
--- a/ciscoconfparse/models_asa.py
+++ b/ciscoconfparse/models_asa.py
@@ -548,6 +548,12 @@ class ASAObjGroupNetwork(ASACfgLine):
 
         return retval
 
+    @property
+    def description(self):
+        retval = self.re_match_iter_typed(r'^\s*description\s+(\S.+)$',
+            result_type=str, default='')
+        return retval
+
 ##
 ##-------------  ASA object-group service
 ##


### PR DESCRIPTION
Add the description property already available in class 'BaseASAIntfLine' to 'ASAObjGroupNetwork' in models_asa.py