### PR TITLE
Contrite penance: never provide fix without testing.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,6 @@ recursive-exclude * *.pyo
 recursive-exclude * *.orig
 recursive-exclude * BUILD.ME
 recursive-exclude * BITBUCKET_HG
-recursive-include tests
+recursive-include tests *
 prune sphinx-doc/_static*
 prune sphinx-doc/_build*

--- a/tests/parse_test.py
+++ b/tests/parse_test.py
@@ -9,12 +9,12 @@ from ciscoconfparse import CiscoConfParse
 if sys.argv[1]=="1":
     parse = CiscoConfParse('../configs/sample_01.ios', syntax='ios', factory=False)
     for line in parse.objs:
-        print line
+        print(line)
 elif sys.argv[1]=="2":
     parse = CiscoConfParse('../configs/sample_01.ios', syntax='ios', factory=True)
     for line in parse.objs:
-        print line
+        print(line)
 elif sys.argv[1]=="3":
     parse = CiscoConfParse('../configs/sample_01.iosxr', syntax='ios', factory=True)
     for line in parse.objs:
-        print line
+        print(line)


### PR DESCRIPTION
To #106 ... with this ``python setup.py sdist`` generates a correct tarball, but still when running ``pytest`` I get (both for py2k and py3k):
```
matej@milic: ciscoconfparse-1.3.17$ pytest-2.7 
=============================================================================================== test session starts ===============================================================================================
platform linux2 -- Python 2.7.15, pytest-3.5.1, py-1.5.2, pluggy-0.6.0
rootdir: /tmp/t/ciscoconfparse-1.3.17, inifile:
plugins: mock-1.10.0, backports.unittest-mock-1.3
collected 295 items / 1 errors                                                                                                                                                                                    

===================================================================================================== ERRORS ======================================================================================================
______________________________________________________________________________________ ERROR collecting tests/parse_test.py _______________________________________________________________________________________
tests/parse_test.py:9: in <module>
    if sys.argv[1]=="1":
E   IndexError: list index out of range
================================================================================================ warnings summary =================================================================================================
None
  Module already imported so cannot be rewritten: backports

-- Docs: http://doc.pytest.org/en/latest/warnings.html
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 errors during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
======================================================================================= 1 warnings, 1 error in 0.45 seconds =======================================================================================
matej@milic: ciscoconfparse-1.3.17$
```