### PR TITLE
changed BANNER_STR_RE to make _banner_mark_regex() work

### DIFF
--- a/ciscoconfparse/ciscoconfparse.py
+++ b/ciscoconfparse/ciscoconfparse.py
@@ -2638,7 +2638,7 @@ class IOSConfigList(MutableSequence):
         banner_objs = list(
             filter(lambda obj: REGEX.search(obj.text), self._list))
 
-        BANNER_STR_RE = r'^(?:(?P<btype>(?:set\s+)*banner\s\w+\s+)(?P<bchar>\S)(?:\S)?)$'
+        BANNER_STR_RE = r'^(?:(?P<btype>(?:set\s+)*banner\s\w+\s+)(?P<bchar>\S)(?:\S+)?)$'
         for parent in banner_objs:
             parent.oldest_ancestor = True
 


### PR DESCRIPTION
Patch Set 1:
 - original function did not work if
 - banner command had more characters after delimeter
 - added a minor fix for that

Signed-off-by: mynameisosama <osama.aftab.1811@gmail.com>