### PR TITLE
Allow importing package from .egg/.zip

### DIFF
--- a/ciscoconfparse/ciscoconfparse.py
+++ b/ciscoconfparse/ciscoconfparse.py
@@ -62,8 +62,15 @@ from models_junos import JunosCfgLine
 """
 
 ## Docstring props: http://stackoverflow.com/a/1523456/667301
-__version__ = open(os.path.join(os.path.dirname(os.path.abspath(__file__)), 
-    'version')).read().strip()
+
+# Support importing module from .egg/.zip
+package_dir = os.path.dirname(os.path.abspath(__file__))
+
+if os.path.isdir(package_dir):
+    __version__ = open(os.path.join(package_dir, 'version')).read().strip()
+else:
+    __version__ = None
+
 __email__ = "mike /at\ pennington [dot] net"
 __author__ = "David Michael Pennington <{0}>".format(__email__)
 __copyright__ = "2007-{0}, {1}".format(time.strftime('%Y'), __author__)


### PR DESCRIPTION
To set `__version__`, the package attempts to read the `version` file. This makes the import fail if the package is not a regular directory but an archive (see, e.g., https://docs.python.org/3/library/zipimport.html), as `__file__` is of the form `path/to/ciscoconfparse.zip/ciscoconfparse.py`.

Packaging a module as an archive can be useful for distribution with tools such as [pyspark](http://spark.apache.org/docs/2.3.0/api/python/pyspark.html#pyspark.SparkContext.addPyFile) and other distributed computation frameworks.

