### PR TITLE
Fix the metadata for sdist.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,4 @@
 colorama
-passlib
-
-[:python_version<'3']
-ipaddr>=2.1.11
 dnspython
-
-[:python_version>='3']
-ipaddress
-dnspython3
+ipaddr>=2.1.11; python_version<'3'
+passlib

--- a/setup.py
+++ b/setup.py
@@ -15,22 +15,6 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 
-## Comment out for Github issue #127
-## Conditionally require the correct ipaddr package in Python2 vs Python3
-#if sys.version_info[0]<3:
-#    IPADDR = "ipaddr>=2.1.11"
-#    DNSPYTHON = "dnspython"
-#else:
-#    IPADDR = "ipaddress"
-#    DNSPYTHON = "dnspython3"
-
-# Ref Github issue #127 - sdist improvements
-REQUIRES = ['colorama', 'passlib']
-EXTRAS = {
-    ":python_version<'3'": ['ipaddr>=2.1.11', 'dnspython'],
-    ":python_version>'3.0'": ['ipaddress', 'dnspython3'],
-}
-
 setup(name='ciscoconfparse',
       version=open(os.path.join(os.path.dirname(os.path.abspath(__file__)),
           'ciscoconfparse', 'version')).read().strip(),
@@ -47,8 +31,14 @@ setup(name='ciscoconfparse',
       packages=find_packages(),
       use_2to3=True,             # Reqd for Windows + Py3 - ref Github issue #32
       zip_safe=False,
-      install_requires = REQUIRES,
-      extras_require = EXTRAS, # Conditional dependencies Github isssue #127
+      install_requires=[
+          'colorama',
+          'dnspython',
+          'passlib',
+          ],
+      extras_require={           # Conditional dependencies Github isssue #127
+          ":python_version<'3'": ['ipaddr>=2.1.11'],
+          },
       #setup_requires=["setuptools_hg"],  # setuptools_hg must be installed as a python module
       classifiers=[
           'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
We're using specification in setup.py extras_require that generates
correct metadata in sdist and wheel packages. Previous use of
conditional statements produced different metadata for different
versions of Python used during the sdist/wheel build.

This approach is compatible with older versions of setuptools. It was
chosen over the newer syntax where environment markers can be used in
the install_requires. The implementation of new approach in setuptools
is just moving such entries from install_requires into keyless marker
extras_require anyway.

This fixes #127.