### PR TITLE
use unittest.mock if available

### DIFF
--- a/tests/test_CiscoConfParse.py
+++ b/tests/test_CiscoConfParse.py
@@ -1,7 +1,10 @@
 from operator import attrgetter
 from itertools import repeat
 from copy import deepcopy
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 import platform
 import sys
 import re


### PR DESCRIPTION
PyPI extra package mock is deprecated and should be replaced by unittest.mock (available since Python 3.3)