### PR TITLE
compare with list of ranges

### DIFF
--- a/tests/test_Ccp_Util.py
+++ b/tests/test_Ccp_Util.py
@@ -99,13 +99,13 @@ def testL4Object_asa_eq02():
 def testL4Object_asa_range01():
     pp = L4Object(protocol="tcp", port_spec="range smtp 32", syntax="asa")
     assert pp.protocol == "tcp"
-    assert pp.port_list == range(25, 33)
+    assert pp.port_list == list(range(25, 33))
 
 
 def testL4Object_asa_lt01():
     pp = L4Object(protocol="tcp", port_spec="lt echo", syntax="asa")
     assert pp.protocol == "tcp"
-    assert pp.port_list == range(1, 7)
+    assert pp.port_list == list(range(1, 7))
 
 
 @pytest.mark.xfail(
@@ -115,7 +115,7 @@ def testL4Object_asa_lt01():
 def testL4Object_asa_lt02():
     pp = L4Object(protocol="tcp", port_spec="lt 7", syntax="asa")
     assert pp.protocol == "tcp"
-    assert pp.port_list == range(1, 7)
+    assert pp.port_list == list(range(1, 7))
 
 
 def testIPv4Obj_contain():


### PR DESCRIPTION
These tests currently fail during the package build for openSUSE (Python 3.6 and 3.8):

```
[   24s] =================================== FAILURES ===================================
[   24s] ___________________________ testL4Object_asa_range01 ___________________________
[   24s] 
[   24s]     def testL4Object_asa_range01():
[   24s]         pp = L4Object(protocol="tcp", port_spec="range smtp 32", syntax="asa")
[   24s]         assert pp.protocol == "tcp"
[   24s] >       assert pp.port_list == range(25, 33)
[   24s] E       assert [25, 26, 27, 28, 29, 30, ...] == range(25, 33)
[   24s] E         Full diff:
[   24s] E         - range(25, 33)
[   24s] E         + [25, 26, 27, 28, 29, 30, 31, 32]
[   24s] 
[   24s] tests/test_Ccp_Util.py:102: AssertionError
[   24s] ____________________________ testL4Object_asa_lt01 _____________________________
[   24s] 
[   24s]     def testL4Object_asa_lt01():
[   24s]         pp = L4Object(protocol="tcp", port_spec="lt echo", syntax="asa")
[   24s]         assert pp.protocol == "tcp"
[   24s] >       assert pp.port_list == range(1, 7)
[   24s] E       assert [1, 2, 3, 4, 5, 6] == range(1, 7)
[   24s] E         Full diff:
[   24s] E         - range(1, 7)
[   24s] E         + [1, 2, 3, 4, 5, 6]
[   24s] 
[   24s] tests/test_Ccp_Util.py:108: AssertionError
[   24s] ____________________________ testL4Object_asa_lt02 _____________________________
[   24s] 
[   24s]     @pytest.mark.xfail(
[   24s]         sys.version_info[0] == 3 and sys.version_info[1] == 2,
[   24s]         reason="Known failure in Python3.2 due to range()",
[   24s]     )
[   24s]     def testL4Object_asa_lt02():
[   24s]         pp = L4Object(protocol="tcp", port_spec="lt 7", syntax="asa")
[   24s]         assert pp.protocol == "tcp"
[   24s] >       assert pp.port_list == range(1, 7)
[   24s] E       assert [1, 2, 3, 4, 5, 6] == range(1, 7)
[   24s] E         Full diff:
[   24s] E         - range(1, 7)
[   24s] E         + [1, 2, 3, 4, 5, 6]
[   24s] 
[   24s] tests/test_Ccp_Util.py:118: AssertionError
```