### PR TITLE
Fixed deprecation warning message due to strings with backslash present

### DIFF
--- a/ciscoconfparse/__init__.py
+++ b/ciscoconfparse/__init__.py
@@ -6,7 +6,7 @@ from ciscoconfparse.ciscoconfparse import __version__
 from ciscoconfparse.ciscoconfparse import *
 from ciscoconfparse.ccp_util import *
 
-""" __init__.py - Parse, Query, Build, and Modify IOS-style configurations
+r""" __init__.py - Parse, Query, Build, and Modify IOS-style configurations
 
      Copyright (C) 2020-2021 David Michael Pennington at Cisco Systems
      Copyright (C) 2019      David Michael Pennington at ThousandEyes

--- a/ciscoconfparse/ccp_util.py
+++ b/ciscoconfparse/ccp_util.py
@@ -29,7 +29,7 @@ else:
     from ipaddress import IPv4Network, IPv6Network, IPv4Address, IPv6Address
     import ipaddress
 
-""" ccp_util.py - Parse, Query, Build, and Modify IOS-style configurations
+r""" ccp_util.py - Parse, Query, Build, and Modify IOS-style configurations
 
      Copyright (C) 2020-2021 David Michael Pennington at Cisco Systems
      Copyright (C) 2019      David Michael Pennington at ThousandEyes
@@ -1227,7 +1227,7 @@ class L4Object(object):
             raise NotImplementedError("This syntax is unknown: '{0}'".format(syntax))
 
         if "eq " in port_spec.strip():
-            port_tmp = re.split("\s+", port_spec)[-1].strip()
+            port_tmp = re.split(r"\s+", port_spec)[-1].strip()
             eq_port = int(ports.get(port_tmp, port_tmp))
             assert 1 <= eq_port <= 65535
             self.port_list = [eq_port]
@@ -1237,23 +1237,23 @@ class L4Object(object):
             assert 1 <= eq_port <= 65535
             self.port_list = [eq_port]
         elif "range " in port_spec.strip():
-            port_tmp = re.split("\s+", port_spec)[1:]
+            port_tmp = re.split(r"\s+", port_spec)[1:]
             low_port = int(ports.get(port_tmp[0], port_tmp[0]))
             high_port = int(ports.get(port_tmp[1], port_tmp[1]))
             assert low_port <= high_port
             self.port_list = sorted(range(low_port, high_port+1))
         elif "lt " in port_spec.strip():
-            port_tmp = re.split("\s+", port_spec)[-1]
+            port_tmp = re.split(r"\s+", port_spec)[-1]
             high_port = int(ports.get(port_tmp, port_tmp))
             assert 65536 >= high_port >= 2
             self.port_list = sorted(range(1, high_port))
         elif "gt " in port_spec.strip():
-            port_tmp = re.split("\s+", port_spec)[-1]
+            port_tmp = re.split(r"\s+", port_spec)[-1]
             low_port = int(ports.get(port_tmp, port_tmp))
             assert 0 < low_port < 65535
             self.port_list = sorted(range(low_port+1, 65536))
         elif "neq " in port_spec.strip():
-            port_str = re.split("\s+", port_spec)[-1]
+            port_str = re.split(r"\s+", port_spec)[-1]
             tmp = set(range(1, 65536))
             tmp.remove(int(port_str))
             self.port_list = sorted(tmp)

--- a/ciscoconfparse/models_asa.py
+++ b/ciscoconfparse/models_asa.py
@@ -18,7 +18,7 @@ from ciscoconfparse.ccp_util import IPv4Obj
 ###
 ###   Use models_asa.py at your own risk.  You have been warned :-)
 
-""" models_asa.py - Parse, Query, Build, and Modify IOS-style configurations
+r""" models_asa.py - Parse, Query, Build, and Modify IOS-style configurations
 
      Copyright (C) 2020-2021 David Michael Pennington at Cisco Systems
      Copyright (C) 2019      David Michael Pennington at ThousandEyes
@@ -895,7 +895,7 @@ class ASARouteLine(BaseASARouteLine):
 
     @classmethod
     def is_object_for(cls, line="", re=re):
-        if re.search("^(ip|ipv6)\s+route\s+\S", line):
+        if re.search(r"^(ip|ipv6)\s+route\s+\S", line):
             return True
         return False
 
@@ -970,7 +970,7 @@ class ASARouteLine(BaseASARouteLine):
 
 
 _ACL_PROTOCOLS = (
-    "ip|tcp|udp|ah|eigrp|esp|gre|igmp|igrp|ipinip|ipsec|ospf|pcp|pim|pptp|snp|\d+"
+    r"ip|tcp|udp|ah|eigrp|esp|gre|igmp|igrp|ipinip|ipsec|ospf|pcp|pim|pptp|snp|\d+"
 )
 _ACL_ICMP_PROTOCOLS = "alternate-address|conversion-error|echo-reply|echo|information-reply|information-request|mask-reply|mask-request|mobile-redirect|parameter-problem|redirect|router-advertisement|router-solicitation|source-quench|time-exceeded|timestamp-reply|timestamp-request|traceroute|unreachable"
 _ACL_LOGLEVELS = r"alerts|critical|debugging|emergencies|errors|informational|notifications|warnings|[0-7]"

--- a/ciscoconfparse/models_cisco.py
+++ b/ciscoconfparse/models_cisco.py
@@ -21,7 +21,7 @@ from ciscoconfparse.ccp_abc import BaseCfgLine
 ###   for this functionality yet, so I consider all this code alpha quality.
 ###
 ###   Use models_cisco.py at your own risk.  You have been warned :-)
-""" models_cisco.py - Parse, Query, Build, and Modify IOS-style configurations
+r""" models_cisco.py - Parse, Query, Build, and Modify IOS-style configurations
 
      Copyright (C) 2020-2021 David Michael Pennington at Cisco Systems
      Copyright (C) 2019      David Michael Pennington at ThousandEyes
@@ -110,7 +110,7 @@ class IOSCfgLine(BaseCfgLine):
     @property
     def is_intf(self):
         # Includes subinterfaces
-        """Returns a boolean (True or False) to answer whether this 
+        r"""Returns a boolean (True or False) to answer whether this
         :class:`~models_cisco.IOSCfgLine` is an interface; subinterfaces
         also return True.
 
@@ -157,7 +157,7 @@ class IOSCfgLine(BaseCfgLine):
 
     @property
     def is_subintf(self):
-        """Returns a boolean (True or False) to answer whether this 
+        r"""Returns a boolean (True or False) to answer whether this
         :class:`~models_cisco.IOSCfgLine` is a subinterface.
 
         Returns
@@ -213,7 +213,7 @@ class IOSCfgLine(BaseCfgLine):
 
     @property
     def is_loopback_intf(self):
-        """Returns a boolean (True or False) to answer whether this 
+        r"""Returns a boolean (True or False) to answer whether this
         :class:`~models_cisco.IOSCfgLine` is a loopback interface.
 
         Returns
@@ -253,7 +253,7 @@ class IOSCfgLine(BaseCfgLine):
 
     @property
     def is_ethernet_intf(self):
-        """Returns a boolean (True or False) to answer whether this 
+        r"""Returns a boolean (True or False) to answer whether this
         :class:`~models_cisco.IOSCfgLine` is an ethernet interface.
         Any ethernet interface (10M through 10G) is considered an ethernet
         interface.
@@ -445,7 +445,7 @@ class BaseIOSIntfLine(IOSCfgLine):
 
     @property
     def name(self):
-        """Return the interface name as a string, such as 'GigabitEthernet0/1'
+        r"""Return the interface name as a string, such as 'GigabitEthernet0/1'
 
         Returns
         -------
@@ -493,7 +493,7 @@ class BaseIOSIntfLine(IOSCfgLine):
 
     @property
     def port(self):
-        """Return the interface's port number
+        r"""Return the interface's port number
 
         Returns
         -------
@@ -535,7 +535,7 @@ class BaseIOSIntfLine(IOSCfgLine):
 
     @property
     def port_type(self):
-        """Return Loopback, ATM, GigabitEthernet, Virtual-Template, etc...
+        r"""Return Loopback, ATM, GigabitEthernet, Virtual-Template, etc...
 
         Returns
         -------
@@ -578,7 +578,7 @@ class BaseIOSIntfLine(IOSCfgLine):
 
     @property
     def ordinal_list(self):
-        """Return a tuple of numbers representing card, slot, port for this interface.  If you call ordinal_list on GigabitEthernet2/25.100, you'll get this python tuple of integers: (2, 25).  If you call ordinal_list on GigabitEthernet2/0/25.100 you'll get this python list of integers: (2, 0, 25).  This method strips all subinterface information in the returned value.
+        r"""Return a tuple of numbers representing card, slot, port for this interface.  If you call ordinal_list on GigabitEthernet2/25.100, you'll get this python tuple of integers: (2, 25).  If you call ordinal_list on GigabitEthernet2/0/25.100 you'll get this python list of integers: (2, 0, 25).  This method strips all subinterface information in the returned value.
 
         Returns
         -------
@@ -631,7 +631,7 @@ class BaseIOSIntfLine(IOSCfgLine):
 
     @property
     def interface_number(self):
-        """Return a string representing the card, slot, port for this interface.  If you call interface_number on GigabitEthernet2/25.100, you'll get this python string: '2/25'.  If you call interface_number on GigabitEthernet2/0/25.100 you'll get this python string '2/0/25'.  This method strips all subinterface information in the returned value.
+        r"""Return a string representing the card, slot, port for this interface.  If you call interface_number on GigabitEthernet2/25.100, you'll get this python string: '2/25'.  If you call interface_number on GigabitEthernet2/0/25.100 you'll get this python string '2/0/25'.  This method strips all subinterface information in the returned value.
 
         Returns
         -------
@@ -681,7 +681,7 @@ class BaseIOSIntfLine(IOSCfgLine):
 
     @property
     def subinterface_number(self):
-        """Return a string representing the card, slot, port for this interface or subinterface.  If you call subinterface_number on GigabitEthernet2/25.100, you'll get this python string: '2/25.100'.  If you call interface_number on GigabitEthernet2/0/25 you'll get this python string '2/0/25'.  This method strips all subinterface information in the returned value.
+        r"""Return a string representing the card, slot, port for this interface or subinterface.  If you call subinterface_number on GigabitEthernet2/25.100, you'll get this python string: '2/25.100'.  If you call interface_number on GigabitEthernet2/0/25 you'll get this python string '2/0/25'.  This method strips all subinterface information in the returned value.
 
         Returns
         -------
@@ -875,7 +875,7 @@ class BaseIOSIntfLine(IOSCfgLine):
     def manual_mtu(self):
         ## Due to the diverse platform defaults, this should be the
         ##    only mtu information I plan to support
-        """Returns a integer value for the manual MTU configured on an
+        r"""Returns a integer value for the manual MTU configured on an
         :class:`~models_cisco.IOSIntfLine` object.  Interfaces without a
         manual MTU configuration return 0.
 
@@ -1028,7 +1028,7 @@ class BaseIOSIntfLine(IOSCfgLine):
         return False
 
     def in_ipv4_subnet(self, ipv4network=IPv4Obj("0.0.0.0/32", strict=False)):
-        """Accept an argument for the :class:`~ccp_util.IPv4Obj` to be 
+        r"""Accept an argument for the :class:`~ccp_util.IPv4Obj` to be
         considered, and return a boolean for whether this interface is within 
         the requested :class:`~ccp_util.IPv4Obj`.
 
@@ -1136,7 +1136,7 @@ class BaseIOSIntfLine(IOSCfgLine):
         ## NOTE: I have no intention of checking self.is_shutdown here
         ##     People should be able to check the sanity of interfaces
         ##     before they put them into production
-        """Return a boolean for whether no ip proxy-arp is configured on the 
+        r"""Return a boolean for whether no ip proxy-arp is configured on the
         interface.
 
         Returns
@@ -1250,7 +1250,7 @@ class BaseIOSIntfLine(IOSCfgLine):
 
     @property
     def ip_helper_addresses(self):
-        """Return a list of dicts with IP helper-addresses.  Each helper-address is in a dictionary.  The dictionary is in this format:
+        r"""Return a list of dicts with IP helper-addresses.  Each helper-address is in a dictionary.  The dictionary is in this format:
 
         Examples
         --------
@@ -1383,22 +1383,22 @@ class BaseIOSIntfLine(IOSCfgLine):
 
             ## For every child object, check whether the vlan list is modified
             abs_str = obj.re_match_typed(
-                "^\s+switchport\s+trunk\s+allowed\s+vlan\s(all|none|\d.*?)$",
+                r"^\s+switchport\s+trunk\s+allowed\s+vlan\s(all|none|\d.*?)$",
                 default="_nomatch_",
                 result_type=str,
             ).lower()
             add_str = obj.re_match_typed(
-                "^\s+switchport\s+trunk\s+allowed\s+vlan\s+add\s+(\d.*?)$",
+                r"^\s+switchport\s+trunk\s+allowed\s+vlan\s+add\s+(\d.*?)$",
                 default="_nomatch_",
                 result_type=str,
             ).lower()
             exc_str = obj.re_match_typed(
-                "^\s+switchport\s+trunk\s+allowed\s+vlan\s+except\s+(\d.*?)$",
+                r"^\s+switchport\s+trunk\s+allowed\s+vlan\s+except\s+(\d.*?)$",
                 default="_nomatch_",
                 result_type=str,
             ).lower()
             rem_str = obj.re_match_typed(
-                "^\s+switchport\s+trunk\s+allowed\s+vlan\s+remove\s+(\d.*?)$",
+                r"^\s+switchport\s+trunk\s+allowed\s+vlan\s+remove\s+(\d.*?)$",
                 default="_nomatch_",
                 result_type=str,
             ).lower()
@@ -1732,7 +1732,7 @@ class IOSIntfGlobal(BaseCfgLine):
     @classmethod
     def is_object_for(cls, line="", re=re):
         if re.search(
-            "^(no\s+cdp\s+run)|(logging\s+event\s+link-status\s+global)|(spanning-tree\sportfast\sdefault)|(spanning-tree\sportfast\sbpduguard\sdefault)",
+            r"^(no\s+cdp\s+run)|(logging\s+event\s+link-status\s+global)|(spanning-tree\sportfast\sdefault)|(spanning-tree\sportfast\sbpduguard\sdefault)",
             line,
         ):
             return True
@@ -1740,31 +1740,31 @@ class IOSIntfGlobal(BaseCfgLine):
 
     @property
     def has_cdp_disabled(self):
-        if self.re_search("^no\s+cdp\s+run\s*"):
+        if self.re_search(r"^no\s+cdp\s+run\s*"):
             return True
         return False
 
     @property
     def has_intf_logging_def(self):
-        if self.re_search("^logging\s+event\s+link-status\s+global"):
+        if self.re_search(r"^logging\s+event\s+link-status\s+global"):
             return True
         return False
 
     @property
     def has_stp_portfast_def(self):
-        if self.re_search("^spanning-tree\sportfast\sdefault"):
+        if self.re_search(r"^spanning-tree\sportfast\sdefault"):
             return True
         return False
 
     @property
     def has_stp_portfast_bpduguard_def(self):
-        if self.re_search("^spanning-tree\sportfast\sbpduguard\sdefault"):
+        if self.re_search(r"^spanning-tree\sportfast\sbpduguard\sdefault"):
             return True
         return False
 
     @property
     def has_stp_mode_rapidpvst(self):
-        if self.re_search("^spanning-tree\smode\srapid-pvst"):
+        if self.re_search(r"^spanning-tree\smode\srapid-pvst"):
             return True
         return False
 
@@ -1827,7 +1827,7 @@ class IOSAccessLine(BaseCfgLine):
     def name(self):
         retval = self.re_match_typed(r"^line\s+(\S+)", result_type=str, default="")
         # special case for IOS async lines: i.e. "line 33 48"
-        if re.search("\d+", retval):
+        if re.search(r"\d+", retval):
             return ""
         return retval
 
@@ -2223,7 +2223,7 @@ class IOSAaaGroupServerLine(BaseCfgLine):
     @property
     def server_private(self, re=re):
         retval = set([])
-        rgx_priv = re.compile("^\s+server-private\s+(\S+)\s")
+        rgx_priv = re.compile(r"^\s+server-private\s+(\S+)\s")
         for cobj in self.children:
             mm = rgx_priv.search(cobj.text)
             if not (mm is None):
@@ -2247,7 +2247,7 @@ class IOSAaaLoginAuthenticationLine(BaseCfgLine):
         )
         self.group = self.re_match_typed(regex, group=2, result_type=str, default="")
         methods_str = self.re_match_typed(regex, group=3, result_type=str, default="")
-        self.methods = methods_str.strip().split("\s")
+        self.methods = methods_str.strip().split(r"\s")
 
     @classmethod
     def is_object_for(cls, line="", re=re):
@@ -2267,7 +2267,7 @@ class IOSAaaEnableAuthenticationLine(BaseCfgLine):
         )
         self.group = self.re_match_typed(regex, group=2, result_type=str, default="")
         methods_str = self.re_match_typed(regex, group=3, result_type=str, default="")
-        self.methods = methods_str.strip().split("\s")
+        self.methods = methods_str.strip().split(r"\s")
 
     @classmethod
     def is_object_for(cls, line="", re=re):
@@ -2288,7 +2288,7 @@ class IOSAaaCommandsAuthorizationLine(BaseCfgLine):
         )
         self.group = self.re_match_typed(regex, group=3, result_type=str, default="")
         methods_str = self.re_match_typed(regex, group=4, result_type=str, default="")
-        self.methods = methods_str.strip().split("\s")
+        self.methods = methods_str.strip().split(r"\s")
 
     @classmethod
     def is_object_for(cls, line="", re=re):

--- a/ciscoconfparse/models_junos.py
+++ b/ciscoconfparse/models_junos.py
@@ -14,7 +14,7 @@ from ciscoconfparse.ccp_util import IPv4Obj
 ###
 ###   Use models_junos.py at your own risk.  You have been warned :-)
 
-""" models_junos.py - Parse, Query, Build, and Modify Junos-style configurations
+r""" models_junos.py - Parse, Query, Build, and Modify Junos-style configurations
 
      Copyright (C) 2020-2021 David Michael Pennington at Cisco Systems
      Copyright (C) 2019      David Michael Pennington at ThousandEyes
@@ -101,7 +101,7 @@ class JunosCfgLine(BaseCfgLine):
     @property
     def is_intf(self):
         # Includes subinterfaces
-        """Returns a boolean (True or False) to answer whether this 
+        r"""Returns a boolean (True or False) to answer whether this
         :class:`~models_junos.JunosCfgLine` is an interface; subinterfaces
         also return True.
 
@@ -145,7 +145,7 @@ class JunosCfgLine(BaseCfgLine):
 
     @property
     def is_subintf(self):
-        """Returns a boolean (True or False) to answer whether this 
+        r"""Returns a boolean (True or False) to answer whether this
         :class:`~models_junos.JunosCfgLine` is a subinterface.
 
         Returns:
@@ -195,7 +195,7 @@ class JunosCfgLine(BaseCfgLine):
 
     @property
     def is_loopback_intf(self):
-        """Returns a boolean (True or False) to answer whether this 
+        r"""Returns a boolean (True or False) to answer whether this
         :class:`~models_junos.JunosCfgLine` is a loopback interface.
 
         Returns:
@@ -231,7 +231,7 @@ class JunosCfgLine(BaseCfgLine):
 
     @property
     def is_ethernet_intf(self):
-        """Returns a boolean (True or False) to answer whether this 
+        r"""Returns a boolean (True or False) to answer whether this
         :class:`~models_junos.JunosCfgLine` is an ethernet interface.
         Any ethernet interface (10M through 10G) is considered an ethernet
         interface.
@@ -356,7 +356,7 @@ class BaseJunosIntfLine(JunosCfgLine):
 
     @property
     def name(self):
-        """Return the interface name as a string, such as 'GigabitEthernet0/1'
+        r"""Return the interface name as a string, such as 'GigabitEthernet0/1'
 
         Returns:
             - str.  The interface name as a string, or '' if the object is not an interface.
@@ -400,7 +400,7 @@ class BaseJunosIntfLine(JunosCfgLine):
 
     @property
     def port(self):
-        """Return the interface's port number
+        r"""Return the interface's port number
 
         Returns:
             - int.  The interface number.
@@ -437,7 +437,7 @@ class BaseJunosIntfLine(JunosCfgLine):
 
     @property
     def port_type(self):
-        """Return Loopback, ATM, GigabitEthernet, Virtual-Template, etc...
+        r"""Return Loopback, ATM, GigabitEthernet, Virtual-Template, etc...
 
         Returns:
             - str.  The port type.
@@ -475,7 +475,7 @@ class BaseJunosIntfLine(JunosCfgLine):
 
     @property
     def ordinal_list(self):
-        """Return a tuple of numbers representing card, slot, port for this interface.  If you call ordinal_list on GigabitEthernet2/25.100, you'll get this python tuple of integers: (2, 25).  If you call ordinal_list on GigabitEthernet2/0/25.100 you'll get this python list of integers: (2, 0, 25).  This method strips all subinterface information in the returned value.
+        r"""Return a tuple of numbers representing card, slot, port for this interface.  If you call ordinal_list on GigabitEthernet2/25.100, you'll get this python tuple of integers: (2, 25).  If you call ordinal_list on GigabitEthernet2/0/25.100 you'll get this python list of integers: (2, 0, 25).  This method strips all subinterface information in the returned value.
 
         Returns:
             - tuple.  A tuple of port numbers as integers.
@@ -563,7 +563,7 @@ class JunosIntfGlobal(BaseCfgLine):
     @classmethod
     def is_object_for(cls, line="", re=re):
         if re.search(
-            "^(no\s+cdp\s+run)|(logging\s+event\s+link-status\s+global)|(spanning-tree\sportfast\sdefault)|(spanning-tree\sportfast\sbpduguard\sdefault)",
+            r"^(no\s+cdp\s+run)|(logging\s+event\s+link-status\s+global)|(spanning-tree\sportfast\sdefault)|(spanning-tree\sportfast\sbpduguard\sdefault)",
             line,
         ):
             return True
@@ -571,31 +571,31 @@ class JunosIntfGlobal(BaseCfgLine):
 
     @property
     def has_cdp_disabled(self):
-        if self.re_search("^no\s+cdp\s+run\s*"):
+        if self.re_search(r"^no\s+cdp\s+run\s*"):
             return True
         return False
 
     @property
     def has_intf_logging_def(self):
-        if self.re_search("^logging\s+event\s+link-status\s+global"):
+        if self.re_search(r"^logging\s+event\s+link-status\s+global"):
             return True
         return False
 
     @property
     def has_stp_portfast_def(self):
-        if self.re_search("^spanning-tree\sportfast\sdefault"):
+        if self.re_search(r"^spanning-tree\sportfast\sdefault"):
             return True
         return False
 
     @property
     def has_stp_portfast_bpduguard_def(self):
-        if self.re_search("^spanning-tree\sportfast\sbpduguard\sdefault"):
+        if self.re_search(r"^spanning-tree\sportfast\sbpduguard\sdefault"):
             return True
         return False
 
     @property
     def has_stp_mode_rapidpvst(self):
-        if self.re_search("^spanning-tree\smode\srapid-pvst"):
+        if self.re_search(r"^spanning-tree\smode\srapid-pvst"):
             return True
         return False
 
@@ -705,7 +705,7 @@ class JunosRouteLine(BaseJunosRouteLine):
 
     @classmethod
     def is_object_for(cls, line="", re=re):
-        if re.search("^(ip|ipv6)\s+route\s+\S", line):
+        if re.search(r"^(ip|ipv6)\s+route\s+\S", line):
             return True
         return False
 

--- a/ciscoconfparse/models_nxos.py
+++ b/ciscoconfparse/models_nxos.py
@@ -20,7 +20,7 @@ from ciscoconfparse.ccp_abc import BaseCfgLine
 ###   THIS FILE IS NOT FULLY FUNCTIONAL.  IT IS INCOMPLETE
 ###
 ###   You have been warned :-)
-""" models_nxos.py - Parse, Query, Build, and Modify IOS-style configurations
+r""" models_nxos.py - Parse, Query, Build, and Modify IOS-style configurations
 
      Copyright (C) 2020-2021 David Michael Pennington at Cisco Systems
      Copyright (C) 2019      David Michael Pennington at ThousandEyes
@@ -87,7 +87,7 @@ class NXOSCfgLine(BaseCfgLine):
     @property
     def is_intf(self):
         # Includes subinterfaces
-        """Returns a boolean (True or False) to answer whether this 
+        r"""Returns a boolean (True or False) to answer whether this
         :class:`~models_nxos.NXOSCfgLine` is an interface; subinterfaces
         also return True.
 
@@ -127,7 +127,7 @@ class NXOSCfgLine(BaseCfgLine):
 
     @property
     def is_subintf(self):
-        """Returns a boolean (True or False) to answer whether this 
+        r"""Returns a boolean (True or False) to answer whether this
         :class:`~models_nxos.NXOSCfgLine` is a subinterface.
 
         Returns:
@@ -174,7 +174,7 @@ class NXOSCfgLine(BaseCfgLine):
 
     @property
     def is_loopback_intf(self):
-        """Returns a boolean (True or False) to answer whether this 
+        r"""Returns a boolean (True or False) to answer whether this
         :class:`~models_nxos.NXOSCfgLine` is a loopback interface.
 
         Returns:
@@ -210,7 +210,7 @@ class NXOSCfgLine(BaseCfgLine):
 
     @property
     def is_ethernet_intf(self):
-        """Returns a boolean (True or False) to answer whether this 
+        r"""Returns a boolean (True or False) to answer whether this
         :class:`~models_nxos.NXOSCfgLine` is an ethernet interface.
         Any ethernet interface (10M through 10G) is considered an ethernet
         interface.
@@ -399,7 +399,7 @@ class BaseNXOSIntfLine(NXOSCfgLine):
 
     @property
     def name(self):
-        """Return the interface name as a string, such as 'GigabitEthernet0/1'
+        r"""Return the interface name as a string, such as 'GigabitEthernet0/1'
 
         Returns:
             - str.  The interface name as a string, or '' if the object is not an interface.
@@ -442,7 +442,7 @@ class BaseNXOSIntfLine(NXOSCfgLine):
 
     @property
     def port(self):
-        """Return the interface's port number
+        r"""Return the interface's port number
 
         Returns:
             - int.  The interface number.
@@ -479,7 +479,7 @@ class BaseNXOSIntfLine(NXOSCfgLine):
 
     @property
     def port_type(self):
-        """Return Loopback, ATM, GigabitEthernet, Virtual-Template, etc...
+        r"""Return Loopback, ATM, GigabitEthernet, Virtual-Template, etc...
 
         Returns:
             - str.  The port type.
@@ -517,7 +517,7 @@ class BaseNXOSIntfLine(NXOSCfgLine):
 
     @property
     def ordinal_list(self):
-        """Return a tuple of numbers representing card, slot, port for this interface.  This method strips all subinterface information in the returned value.  If you call ordinal_list on GigabitEthernet2/25.100, you'll get this python tuple of integers: (2, 25).  If you call ordinal_list on GigabitEthernet2/0/25.100 you'll get this python list of integers: (2, 0, 25).
+        r"""Return a tuple of numbers representing card, slot, port for this interface.  This method strips all subinterface information in the returned value.  If you call ordinal_list on GigabitEthernet2/25.100, you'll get this python tuple of integers: (2, 25).  If you call ordinal_list on GigabitEthernet2/0/25.100 you'll get this python list of integers: (2, 0, 25).
 
         Returns:
             - tuple.  A tuple of port numbers as integers.
@@ -565,7 +565,7 @@ class BaseNXOSIntfLine(NXOSCfgLine):
 
     @property
     def interface_number(self):
-        """Return a string representing the card, slot, port for this interface.  If you call interface_number on GigabitEthernet2/25.100, you'll get this python string: '2/25'.  If you call interface_number on GigabitEthernet2/0/25.100 you'll get this python string '2/0/25'.  This method strips all subinterface information in the returned value.
+        r"""Return a string representing the card, slot, port for this interface.  If you call interface_number on GigabitEthernet2/25.100, you'll get this python string: '2/25'.  If you call interface_number on GigabitEthernet2/0/25.100 you'll get this python string '2/0/25'.  This method strips all subinterface information in the returned value.
 
         Returns:
             - string.
@@ -611,7 +611,7 @@ class BaseNXOSIntfLine(NXOSCfgLine):
 
     @property
     def subinterface_number(self):
-        """Return a string representing the card, slot, port for this interface or subinterface.  If you call subinterface_number on GigabitEthernet2/25.100, you'll get this python string: '2/25.100'.  If you call interface_number on GigabitEthernet2/0/25 you'll get this python string '2/0/25'.  This method strips all subinterface information in the returned value.
+        r"""Return a string representing the card, slot, port for this interface or subinterface.  If you call subinterface_number on GigabitEthernet2/25.100, you'll get this python string: '2/25.100'.  If you call interface_number on GigabitEthernet2/0/25 you'll get this python string '2/0/25'.  This method strips all subinterface information in the returned value.
 
         Returns:
             - string.
@@ -815,7 +815,7 @@ class BaseNXOSIntfLine(NXOSCfgLine):
     def manual_mtu(self):
         ## Due to the diverse platform defaults, this should be the
         ##    only mtu information I plan to support
-        """Returns a integer value for the manual MTU configured on an
+        r"""Returns a integer value for the manual MTU configured on an
         :class:`~models_nxos.NXOSIntfLine` object.  Interfaces without a
         manual MTU configuration return 0.
 
@@ -950,7 +950,7 @@ class BaseNXOSIntfLine(NXOSCfgLine):
         return False
 
     def in_ipv4_subnet(self, ipv4network=IPv4Obj("0.0.0.0/32", strict=False)):
-        """Accept an argument for the :class:`~ccp_util.IPv4Obj` to be 
+        r"""Accept an argument for the :class:`~ccp_util.IPv4Obj` to be
         considered, and return a boolean for whether this interface is within 
         the requested :class:`~ccp_util.IPv4Obj`.
 
@@ -1052,7 +1052,7 @@ class BaseNXOSIntfLine(NXOSCfgLine):
         ## NOTE: I have no intention of checking self.is_shutdown here
         ##     People should be able to check the sanity of interfaces
         ##     before they put them into production
-        """Return a boolean for whether no ip proxy-arp is configured on the 
+        r"""Return a boolean for whether no ip proxy-arp is configured on the
         interface.
 
         Returns:
@@ -1163,7 +1163,7 @@ class BaseNXOSIntfLine(NXOSCfgLine):
 
     @property
     def ip_helper_addresses(self):
-        """Return a list of dicts with IP helper-addresses.  Each helper-address is in a dictionary.  The dictionary is in this format:
+        r"""Return a list of dicts with IP helper-addresses.  Each helper-address is in a dictionary.  The dictionary is in this format:
 
         .. code-block:: python
            :emphasize-lines: 11
@@ -1336,22 +1336,22 @@ class BaseNXOSIntfLine(NXOSCfgLine):
 
             ## For every child object, check whether the vlan list is modified
             abs_str = obj.re_match_typed(
-                "^\s+switchport\s+trunk\s+allowed\s+vlan\s(all|none|\d.*?)$",
+                r"^\s+switchport\s+trunk\s+allowed\s+vlan\s(all|none|\d.*?)$",
                 default="_nomatch_",
                 result_type=str,
             ).lower()
             add_str = obj.re_match_typed(
-                "^\s+switchport\s+trunk\s+allowed\s+vlan\s+add\s+(\d.*?)$",
+                r"^\s+switchport\s+trunk\s+allowed\s+vlan\s+add\s+(\d.*?)$",
                 default="_nomatch_",
                 result_type=str,
             ).lower()
             exc_str = obj.re_match_typed(
-                "^\s+switchport\s+trunk\s+allowed\s+vlan\s+except\s+(\d.*?)$",
+                r"^\s+switchport\s+trunk\s+allowed\s+vlan\s+except\s+(\d.*?)$",
                 default="_nomatch_",
                 result_type=str,
             ).lower()
             rem_str = obj.re_match_typed(
-                "^\s+switchport\s+trunk\s+allowed\s+vlan\s+remove\s+(\d.*?)$",
+                r"^\s+switchport\s+trunk\s+allowed\s+vlan\s+remove\s+(\d.*?)$",
                 default="_nomatch_",
                 result_type=str,
             ).lower()
@@ -1711,7 +1711,7 @@ class NXOSIntfGlobal(BaseCfgLine):
     @classmethod
     def is_object_for(cls, line="", re=re):
         if re.search(
-            "^(no\s+cdp\s+run)|(logging\s+event\s+link-status\s+global)|(spanning-tree\sportfast\sdefault)|(spanning-tree\sportfast\sbpduguard\sdefault)",
+            r"^(no\s+cdp\s+run)|(logging\s+event\s+link-status\s+global)|(spanning-tree\sportfast\sdefault)|(spanning-tree\sportfast\sbpduguard\sdefault)",
             line,
         ):
             return True
@@ -1719,25 +1719,25 @@ class NXOSIntfGlobal(BaseCfgLine):
 
     @property
     def has_cdp_disabled(self):
-        if self.re_search("^no\s+cdp\s+run\s*"):
+        if self.re_search(r"^no\s+cdp\s+run\s*"):
             return True
         return False
 
     @property
     def has_intf_logging_def(self):
-        if self.re_search("^logging\s+event\s+link-status\s+global"):
+        if self.re_search(r"^logging\s+event\s+link-status\s+global"):
             return True
         return False
 
     @property
     def has_stp_portfast_bpduguard_def(self):
-        if self.re_search("^spanning-tree\sportfast\sbpduguard\sdefault"):
+        if self.re_search(r"^spanning-tree\sportfast\sbpduguard\sdefault"):
             return True
         return False
 
     @property
     def has_stp_mode_rapidpvst(self):
-        if self.re_search("^spanning-tree\smode\srapid-pvst"):
+        if self.re_search(r"^spanning-tree\smode\srapid-pvst"):
             return True
         return False
 
@@ -1947,7 +1947,7 @@ class NXOSAccessLine(BaseCfgLine):
     def name(self):
         retval = self.re_match_typed(r"^line\s+(\S+)", result_type=str, default="")
         # special case for IOS async lines: i.e. "line 33 48"
-        if re.search("\d+", retval):
+        if re.search(r"\d+", retval):
             return ""
         return retval
 
@@ -2284,7 +2284,7 @@ class NXOSAaaGroupServerLine(BaseCfgLine):
     @property
     def server_private(self, re=re):
         retval = set([])
-        rgx_priv = re.compile("^\s+server-private\s+(\S+)\s")
+        rgx_priv = re.compile(r"^\s+server-private\s+(\S+)\s")
         for cobj in self.children:
             mm = rgx_priv.search(cobj.text)
             if not (mm is None):
@@ -2308,7 +2308,7 @@ class NXOSAaaLoginAuthenticationLine(BaseCfgLine):
         )
         self.group = self.re_match_typed(regex, group=2, result_type=str, default="")
         methods_str = self.re_match_typed(regex, group=3, result_type=str, default="")
-        self.methods = methods_str.strip().split("\s")
+        self.methods = methods_str.strip().split(r"\s")
 
     @classmethod
     def is_object_for(cls, line="", re=re):
@@ -2328,7 +2328,7 @@ class NXOSAaaEnableAuthenticationLine(BaseCfgLine):
         )
         self.group = self.re_match_typed(regex, group=2, result_type=str, default="")
         methods_str = self.re_match_typed(regex, group=3, result_type=str, default="")
-        self.methods = methods_str.strip().split("\s")
+        self.methods = methods_str.strip().split(r"\s")
 
     @classmethod
     def is_object_for(cls, line="", re=re):
@@ -2349,7 +2349,7 @@ class NXOSAaaCommandsAuthorizationLine(BaseCfgLine):
         )
         self.group = self.re_match_typed(regex, group=3, result_type=str, default="")
         methods_str = self.re_match_typed(regex, group=4, result_type=str, default="")
-        self.methods = methods_str.strip().split("\s")
+        self.methods = methods_str.strip().split(r"\s")
 
     @classmethod
     def is_object_for(cls, line="", re=re):

--- a/ciscoconfparse/protocol_values.py
+++ b/ciscoconfparse/protocol_values.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-""" protocol_values.py - Parse, Query, Build, and Modify IOS-style configurations
+r""" protocol_values.py - Parse, Query, Build, and Modify IOS-style configurations
      Copyright (C) 2020-2021 David Michael Pennington at Cisco Systems
      Copyright (C) 2019      David Michael Pennington at ThousandEyes
      Copyright (C) 2014-2019 David Michael Pennington at Samsung Data Services


### PR DESCRIPTION
Fixed deprecation warning messages present in python 3.8 due to strings with
backslash present.


Example: 
ciscoconfparse/ciscoconfparse.py:572: DeprecationWarning: invalid escape sequence s