### PR TITLE
Fixing ipaddr requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,12 +30,12 @@ classifiers=[
 
 
 [tool.poetry.dependencies]
-python = ">=3.6"
+python = ">=3.6.1"
 passlib = "^1.7.4"
 dnspython = "^2.1.0"
 loguru = "0.5.3"
 toml = "0.10.2"
-ipaddress = ">=2.1.11"
+ipaddr = { version = ">=2.1.11", python = "<3.3" }
 
 [tool.poetry.dev-dependencies]
 pytest = "6.2.4"


### PR DESCRIPTION
Two changes:
1. `python >= 3.6.1 `-- `poetry install` did not like `pre-commit = "2.16.0"`
2. Changed ipaddress back to ipaddr and added a `python <3.3` to avoid installing ipaddr on python versions 3.3 and above.

The code seems to already handle ipaddress/ipaddr shift in code already, so change number 2 should be fine from a code perspective.