### PR TITLE
In pyproject.toml, correct readme file name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     "Mike Pennington <mike@pennington.net>",
 ]
 license = "GPLv3"
-readme = "README.rst"
+readme = "README.md"
 homepage = "https://github.com/mpenning/ciscoconfparse"
 documentation = "http://www.pennington.net/py/ciscoconfparse/"
 keywords = ["Parse", "audit", "query", "modify", "Cisco IOS", "Cisco", "NXOS", "ASA", "Juniper",]


### PR DESCRIPTION
pyproject.toml referenced a readme file named README.rst, which no longer exists. Altered to README.md.