### PR TITLE
A suggestion for BaseIOSIntfLine.voice_vlan analogously to BaseIOSIntfLine.access_vlan

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@
     - Add a dedicated bootstrap method (`_bootstrap_obj_init_junos()`) for parsing `syntax==junos`
     - Add `JunosCfgLine()`
     - Add `ciscoconfparse/models_iosxr.py` which is mostly broken (but this also comes with the caveat of an 'unsupported feature').  Ref   - [Github issue #235](https://github.com/mpenning/ciscoconfparse/issues/235)
-    - Restore `tests/test_CiscoConfParse.py` to proper functionality.  See [git commit hash 840b11ce334f0b7120bbfc90d2d83fbdc5ed1bd1](ht  tps://github.com/mpenning/ciscoconfparse/commit/840b11ce334f0b7120bbfc90d2d83fbdc5ed1bd1)
+    - Restore `tests/test_CiscoConfParse.py` to proper functionality.  See [git commit hash `840b11ce334f0b7120bbfc90d2d83fbdc5ed1bd1`](https://github.com/mpenning/ciscoconfparse/commit/840b11ce334f0b7120bbfc90d2d83fbdc5ed1bd1)
     - Remove `NXOSConfigList()` and `ASAConfigList()` which were dead code and unused
     - Change `ignore_blank_lines` behavior for [Github Issue #229](https://github.com/mpenning/ciscoconfparse/issues/229).  Now blank line  s are always allowed in banners or macros regardless of what `ignore_blank_lines` is set to.
     - Rename loop variables that overlapped scope with other code sections

--- a/ciscoconfparse/models_cisco.py
+++ b/ciscoconfparse/models_cisco.py
@@ -1368,6 +1368,20 @@ class BaseIOSIntfLine(IOSCfgLine):
         return retval
 
     @property
+    def voice_vlan(self):
+        r"""Return an integer with the voice vlan number.  Return 1, if the switchport has no explicit voice vlan configured; return 0 if the port isn't a switchport"""
+        if self.is_switchport:
+            default_val = 1
+        else:
+            default_val = 0
+        retval = self.re_match_iter_typed(
+            r"^\s*switchport\s+voice\s+vlan\s+(\d+)$",
+            result_type=int,
+            default=default_val,
+        )
+        return retval
+
+    @property
     def trunk_vlans_allowed(self):
         r"""Return a CiscoRange() with the list of allowed vlan numbers (as int).  Return 0 if the port isn't a switchport in trunk mode"""
 


### PR DESCRIPTION
Here is a simple addition to BaseIOSIntfLine for voice VLANs.

It is pretty much copied from access_vlan. I'm not sure about the behaviour in the case of it not being defined - but I have the same reservations about access_vlan - I would have preferred to return None in both cases.