### PR TITLE
Fix functionality of delete_children_matching 

### DIFF
--- a/ciscoconfparse/ccp_abc.py
+++ b/ciscoconfparse/ccp_abc.py
@@ -19,6 +19,7 @@ r""" ccp_abc.py - Parse, Query, Build, and Modify IOS-style configurations
 
 from difflib import get_close_matches
 from operator import methodcaller
+from collections import deque
 from abc import ABCMeta
 import warnings
 import inspect
@@ -538,10 +539,10 @@ class BaseCfgLine(metaclass=ABCMeta):
            !
            >>>
         """
-        cobjs = filter(methodcaller("re_search", linespec), self.children)
+        cobjs = list(filter(methodcaller("re_search", linespec), self.children))
         retval = [ii.text for ii in cobjs]
         # Delete the children
-        map(methodcaller("delete"), cobjs)
+        deque(map(methodcaller("delete"), cobjs))
         return retval
 
     # On BaseCfgLine()

--- a/ciscoconfparse/ccp_abc.py
+++ b/ciscoconfparse/ccp_abc.py
@@ -18,8 +18,6 @@ r""" ccp_abc.py - Parse, Query, Build, and Modify IOS-style configurations
 """
 
 from difflib import get_close_matches
-from operator import methodcaller
-from collections import deque
 from abc import ABCMeta
 import warnings
 import inspect
@@ -539,10 +537,8 @@ class BaseCfgLine(metaclass=ABCMeta):
            !
            >>>
         """
-        cobjs = list(filter(methodcaller("re_search", linespec), self.children))
-        retval = [ii.text for ii in cobjs]
-        # Delete the children
-        deque(map(methodcaller("delete"), cobjs))
+        # if / else in a list comprehension... ref ---> https://stackoverflow.com/a/9442777/667301
+        retval = [(obj.delete() if obj.re_search(linespec) else obj) for obj in self.children]
         return retval
 
     # On BaseCfgLine()

--- a/tests/test_CiscoConfParse.py
+++ b/tests/test_CiscoConfParse.py
@@ -1235,6 +1235,31 @@ def testValues_find_objects_w_all_children(parse_c01):
     )
     assert test_result == result_correct
 
+def testValues_delete_children_matching():
+    config = [
+        '!',
+        'interface Serial1/0',
+        ' description Some lame description',
+        ' ip address 1.1.1.1 255.255.255.252',
+        '!',
+        'interface Serial1/1',
+        ' description Another lame description',
+        ' ip address 1.1.1.5 255.255.255.252',
+        '!',
+    ]
+    result_correct = [
+        '!',
+        'interface Serial1/0',
+        ' ip address 1.1.1.1 255.255.255.252',
+        '!',
+        'interface Serial1/1',
+        ' ip address 1.1.1.5 255.255.255.252',
+        '!',
+    ]
+    parse = CiscoConfParse(config, syntax="ios")
+    for obj in parse.find_objects(r'^interface'):
+        obj.delete_children_matching('description')
+    assert parse.ioscfg == result_correct
 
 def testValues_delete_lines_01():
     """Catch bugs similar to those fixed by https://github.com/mpenning/ciscoconfparse/pull/140"""


### PR DESCRIPTION
Fixes two issues with delete_children_matching as reported on #241 that I just ran into myself as well. Casts the resulting iterable from filter into a list. Since it's consumed by both the list comprehension for `retval`, it was already exhausted when arriving at the `map`. Also uses to deque to consume the `map` iterable, as it's not executed until the items are iterated over. (I think this behavior changed somewhere in 3.x, it used to return a list) Could also just cast to a list of refactor to a for loop here, but I think `deque` is the fastest way to consume it. 