### PR TITLE
Fix interface description with one character

### DIFF
--- a/ciscoconfparse/models_cisco.py
+++ b/ciscoconfparse/models_cisco.py
@@ -732,7 +732,7 @@ class BaseIOSIntfLine(IOSCfgLine):
 
         """
         retval = self.re_match_iter_typed(
-            r"^\s*description\s+(\S.+)$", result_type=str, default=""
+            r"^\s*description\s+(.+)$", result_type=str, default=""
         )
         return retval
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -296,6 +296,7 @@ interface GigabitEthernet4/1
  power inline static max 7000
 !
 interface GigabitEthernet4/2
+ description A
  switchport
  switchport access vlan 100
  switchport voice vlan 150

--- a/tests/test_Models_Cisco.py
+++ b/tests/test_Models_Cisco.py
@@ -866,7 +866,7 @@ def testVal_IOSIntfLine_description(parse_c03_factory):
         "interface Serial 1/0": "Uplink to SBC F923X2K425",
         "interface Serial 1/1": "Uplink to AT&T",
         "interface GigabitEthernet4/1": "",
-        "interface GigabitEthernet4/2": "",
+        "interface GigabitEthernet4/2": "A",
         "interface GigabitEthernet4/3": "",
         "interface GigabitEthernet4/4": "",
         "interface GigabitEthernet4/5": "",


### PR DESCRIPTION
[Bug]: IOSIntfLine object incorrectly parses an interface description containing a single character

.. code:: python

	import re
	
	from ciscoconfparse import CiscoConfParse
	
	text = """
	interface Ethernet1/1
	  description A
	"""
	
	ccp = CiscoConfParse(text.splitlines(), factory=True)
	intf = ccp.find_objects("^interface .+")[0]
	descr = intf.description
	

	assert descr == "A"

